### PR TITLE
fix P2 Forsaken Light of Judgment label

### DIFF
--- a/waju-sim/scenes/dmu/p2/p2_fors_seq.gd
+++ b/waju-sim/scenes/dmu/p2/p2_fors_seq.gd
@@ -796,9 +796,9 @@ func move_final_pos():
 	move_party_rtd(ForsPositions.PAST_BAIT_POS)
 
 
-## Cast Light of Judgement (for mit check)
+## Cast Light of Judgment (for mit check)
 func cast_light_judgement():
-	cast_bar.cast("Light of Judgement", 4.7)
+	cast_bar.cast("Light of Judgment", 4.7)
 
 
 func ending_cast():


### PR DESCRIPTION
Summary:
- Update the P2 Forsaken cast label from `Light of Judgement` to `Light of Judgment`.
- Keep the adjacent comment spelling consistent with the cast text.

Addresses #5.

Validation:
- `rg -n "Light of Judgement|Light of Judgment|Judgement|Judgment" waju-sim/scenes/dmu/p2/p2_fors_seq.gd -S`
- `git diff --check`

I did not run the Godot project locally because no `godot`/`godot4` binary is available in this environment. The patch only changes one comment and one user-facing string.