### PR TITLE
Fix tank job icons to match tank models

### DIFF
--- a/waju-sim/scenes/common/player_characters/lockon/role_icons/t1_icon.tscn
+++ b/waju-sim/scenes/common/player_characters/lockon/role_icons/t1_icon.tscn
@@ -1,6 +1,6 @@
 [gd_scene format=3 uid="uid://cwt0tgk120vpy"]
 
-[ext_resource type="Texture2D" uid="uid://d08jlse22swvx" path="res://assets/common/icons/job_icons/pld_icon.png" id="1_lsl5q"]
+[ext_resource type="Texture2D" uid="uid://r3tm7ser2hi6" path="res://assets/common/icons/job_icons/war_icon.png" id="1_lsl5q"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_65dy5"]
 transparency = 1

--- a/waju-sim/scenes/common/player_characters/lockon/role_icons/t2_icon.tscn
+++ b/waju-sim/scenes/common/player_characters/lockon/role_icons/t2_icon.tscn
@@ -1,6 +1,6 @@
 [gd_scene format=3 uid="uid://bttkkatayk4i8"]
 
-[ext_resource type="Texture2D" uid="uid://r3tm7ser2hi6" path="res://assets/common/icons/job_icons/war_icon.png" id="1_l45b2"]
+[ext_resource type="Texture2D" path="res://assets/common/icons/job_icons/gnb_icon.png" id="1_l45b2"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_65dy5"]
 transparency = 1

--- a/waju-sim/scenes/ui/party_list/party_list.tscn
+++ b/waju-sim/scenes/ui/party_list/party_list.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="FontFile" uid="uid://46wxmrxlq74f" path="res://assets/common/fonts/eurostarregularextended.ttf" id="12_g1bna"]
 [ext_resource type="Script" uid="uid://b1dsbp8c7qn58" path="res://scenes/ui/party_list/member_container.gd" id="13_xtixg"]
 [ext_resource type="Texture2D" uid="uid://daghgymd8abek" path="res://assets/common/icons/ui_icons/1_icon.png" id="14_2f2wp"]
-[ext_resource type="Texture2D" uid="uid://d08jlse22swvx" path="res://assets/common/icons/job_icons/pld_icon.png" id="14_6musf"]
+[ext_resource type="Texture2D" path="res://assets/common/icons/job_icons/gnb_icon.png" id="14_6musf"]
 [ext_resource type="Texture2D" uid="uid://r3tm7ser2hi6" path="res://assets/common/icons/job_icons/war_icon.png" id="16_hxi8r"]
 [ext_resource type="Texture2D" uid="uid://ci4i6c0pbxw5b" path="res://assets/common/icons/job_icons/sch_icon.png" id="17_xwuni"]
 [ext_resource type="Texture2D" uid="uid://pdr8y0w61wj1" path="res://assets/common/icons/job_icons/sam_icon.png" id="18_lcryu"]
@@ -147,7 +147,7 @@ size_flags_vertical = 4
 [node name="RoleIconTexture" parent="MarginContainer/TextureRect/VBoxContainer/MemberVBoxContainer/T1MemberContainer/HBoxContainer/RoleIcon" unique_id=1038873005 instance=ExtResource("6_ipj6x")]
 custom_minimum_size = Vector2(25, 0)
 layout_mode = 2
-texture = ExtResource("14_6musf")
+texture = ExtResource("16_hxi8r")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/TextureRect/VBoxContainer/MemberVBoxContainer/T1MemberContainer/HBoxContainer" unique_id=112332365]
 layout_mode = 2
@@ -295,7 +295,7 @@ size_flags_vertical = 4
 [node name="RoleIconTexture" parent="MarginContainer/TextureRect/VBoxContainer/MemberVBoxContainer/T2MemberContainer/HBoxContainer/RoleIcon" unique_id=2052534894 instance=ExtResource("6_ipj6x")]
 custom_minimum_size = Vector2(25, 0)
 layout_mode = 2
-texture = ExtResource("16_hxi8r")
+texture = ExtResource("14_6musf")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/TextureRect/VBoxContainer/MemberVBoxContainer/T2MemberContainer/HBoxContainer" unique_id=512043730]
 layout_mode = 2


### PR DESCRIPTION
The party-list and overhead job icons labeled Tank 1 as Paladin and Tank 2
as Warrior, but the 3D models are Warrior (t1) and Gunbreaker (t2) — the
icons and models were reversed. There is no Paladin asset in the project.

This aligns all three representations so **Tank 1 = Warrior** and
**Tank 2 = Gunbreaker**:
- `party_list.tscn`: T1 icon → `war_icon`, T2 icon → `gnb_icon`
- `t1_icon.tscn` (overhead): `pld_icon` → `war_icon`
- `t2_icon.tscn` (overhead): `war_icon` → `gnb_icon`

⚠️ Note: `gnb_icon` is referenced by path only. The asset must exist at
`res://assets/common/icons/job_icons/gnb_icon.png` for the Tank 2 icon to render.