### PR TITLE
fix invert y option not affecting mouse camera

### DIFF
--- a/waju-sim/scenes/common/player_characters/player_movement_controller.gd
+++ b/waju-sim/scenes/common/player_characters/player_movement_controller.gd
@@ -211,7 +211,10 @@ func _unhandled_input(event : InputEvent) -> void:
 	if event is InputEventMouseMotion:
 		if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
 			twist_input = - event.relative.x * mouse_sensitivity
-			pitch_input = - event.relative.y * mouse_sensitivity
+			if invert_y:
+				pitch_input = event.relative.y * mouse_sensitivity
+			else:
+				pitch_input = - event.relative.y * mouse_sensitivity
 			# Get left click movement to exclude click/drags
 			mouse_travel += event.relative
 	# Mouse button pressed.
@@ -293,7 +296,7 @@ func on_spectate_mode_changed() -> void:
 func on_variable_saved(_section: String, key: String, _value: Variant) -> void:
 	if key.contains("sens") or key == "invert_y":
 		mouse_sensitivity = BASE_MOUSE_SENS * SavedVariables.save_data["settings"]["mouse_sens"]
-		x_sensitivity = BASE_Y_SENS * SavedVariables.save_data["settings"]["x_sens"]
+		x_sensitivity = BASE_X_SENS * SavedVariables.save_data["settings"]["x_sens"]
 		y_sensitivity = BASE_Y_SENS * SavedVariables.save_data["settings"]["y_sens"]
 		invert_y = SavedVariables.save_data["settings"]["invert_y"]
 


### PR DESCRIPTION
fixes #2

the invert y toggle only affected the controller right stick, mouse camera pitch ignored it. this applies the same inversion to the mouse-look path in player_movement_controller.gd, mirroring the existing right-stick branch. the movement controller is shared, so this covers dmu, fru, and dsr alike. live toggle updates already work through on_variable_saved, so no extra wiring was needed.

also fixes a small copy-paste typo in on_variable_saved where the x sensitivity was rescaled with the y base constant (no behavior change, both constants are equal).

tested in the fru sim (godot 4.7, macos): mouse pitch inverts with the toggle on and reverts with it off, including when toggled mid-run. the controller stick path is unchanged (no gamepad on hand to re-test).